### PR TITLE
ci: pin GitHub Actions to latest stable SHA commits

### DIFF
--- a/.github/workflows/compile_tex.yml
+++ b/.github/workflows/compile_tex.yml
@@ -36,7 +36,7 @@ jobs:
           fi
       
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4.0.2
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: arn:aws:iam::977913560033:role/githubactions
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
@@ -48,7 +48,7 @@ jobs:
       #     aws sts get-caller-identity
 
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f # v7.0.0
 
       # - name: Print working directory (debug step)
       #   run: |


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v4 → v7
- Bump `aws-actions/configure-aws-credentials` from v4 → v6.2.2
- Updated workflow: `compile_tex.yml`

## Test plan
- [ ] Confirm compile workflow still runs successfully
- [ ] Verify AWS credentials configuration still works if applicable